### PR TITLE
Fix duplicate string identifiers

### DIFF
--- a/malwares.yara
+++ b/malwares.yara
@@ -30,14 +30,14 @@ global private rule IsPhp
 private rule IRC
 {
     strings:
-        $ = "USER" fullword
-        $ = "PASS" fullword
-        $ = "PRIVMSG" fullword
-        $ = "MODE" fullword
-        $ = "PING" fullword
-        $ = "PONG" fullword
-        $ = "JOIN" fullword
-        $ = "PART" fullword
+        $user = "USER" fullword
+        $pass = "PASS" fullword
+        $privmsg = "PRIVMSG" fullword
+        $mode = "MODE" fullword
+        $ping = "PING" fullword
+        $pong = "PONG" fullword
+        $join = "JOIN" fullword
+        $part = "PART" fullword
 
     condition:
         5 of them
@@ -46,9 +46,9 @@ private rule IRC
 private rule CloudFlareBypass
 {
     strings:
-        $ = "chk_jschl"
-        $ = "jschl_vc"
-        $ = "jschl_answer"
+        $chk_jschl = "chk_jschl"
+        $jschl_vc = "jschl_vc"
+        $jschl_answer = "jschl_answer"
 
     condition:
         2 of them // Better be safe than sorry
@@ -133,38 +133,38 @@ rule DangerousPhp
     strings:
         $system = "system" fullword  // localroot bruteforcers have a lot of this
 
-        $ = "exec" fullword
-        $ = "eval" fullword
-        $ = "shell_exec" fullword
-        $ = "passthru" fullword
-        $ = "posix_getuid" fullword
-        $ = "posix_geteuid" fullword
-        $ = "posix_getgid" fullword
-        $ = "phpinfo" fullword
-        $ = "backticks" fullword
-        $ = "proc_open" fullword
-        $ = "win_shell_execute" fullword
-        $ = "win32_create_service" fullword
-        $ = "posix_getpwuid" fullword
-        $ = "shm_open" fullword
-        $ = "assert" fullword
-        $ = "fsockopen" fullword
-        $ = "function_exists" fullword
-        $ = "getmygid" fullword
-        $ = "php_uname" fullword
-        $ = "socket_create(AF_INET, SOCK_STREAM, SOL_TCP)"
-        $ = "fpassthru" fullword
-        $ = "posix_setuid" fullword
-        $ = "xmlrpc_decode" fullword
-        $ = "show_source" fullword
-        $ = "pcntl_exec" fullword
-        $ = "array_filter" fullword
-        $ = "call_user_func" fullword
-        $ = "register_shutdown_function" fullword
-        $ = "register_tick_function" fullword
-        $ = /ob_start\s*\(\s*[^\)]/  //ob_start('assert'); echo $_REQUEST['pass']; ob_end_flush();
-        $ = "mb_ereg_replace_callback" fullword
-        $ = "preg_replace_callback" fullword
+        $exec = "exec" fullword
+        $eval = "eval" fullword
+        $shell_exec = "shell_exec" fullword
+        $passthru = "passthru" fullword
+        $posix_getuid = "posix_getuid" fullword
+        $posix_geteuid = "posix_geteuid" fullword
+        $posix_getgid = "posix_getgid" fullword
+        $phpinfo = "phpinfo" fullword
+        $backticks = "backticks" fullword
+        $proc_open = "proc_open" fullword
+        $win_shell_execute = "win_shell_execute" fullword
+        $win32_create_service = "win32_create_service" fullword
+        $posix_getpwuid = "posix_getpwuid" fullword
+        $shm_open = "shm_open" fullword
+        $assert = "assert" fullword
+        $fsockopen = "fsockopen" fullword
+        $function_exists = "function_exists" fullword
+        $getmygid = "getmygid" fullword
+        $php_uname = "php_uname" fullword
+        $socket_create = "socket_create(AF_INET, SOCK_STREAM, SOL_TCP)"
+        $fpassthru = "fpassthru" fullword
+        $posix_setuid = "posix_setuid" fullword
+        $xmlrpc_decode = "xmlrpc_decode" fullword
+        $show_source = "show_source" fullword
+        $pcntl_exec = "pcntl_exec" fullword
+        $array_filter = "array_filter" fullword
+        $call_user_func = "call_user_func" fullword
+        $register_shutdown_function = "register_shutdown_function" fullword
+        $register_tick_function = "register_tick_function" fullword
+        $ob_start = /ob_start\s*\(\s*[^\)]/  //ob_start('assert'); echo $_REQUEST['pass']; ob_end_flush();
+        $mb_ereg_replace_callback = "mb_ereg_replace_callback" fullword
+        $preg_replace_callback = "preg_replace_callback" fullword
 
         $whitelist = /escapeshellcmd|escapeshellarg/
 
@@ -175,38 +175,38 @@ rule DangerousPhp
 rule DodgyStrings
 {
     strings:
-        $ = "/../../../"
-        $ = /\/bin\/(ba)?sh/ fullword
-        $ = "/etc/passwd"
-        $ = "/etc/proftpd.conf"
-        $ = "/etc/resolv.conf"
-        $ = "/etc/shadow"
-        $ = "/etc/syslog.conf"
-        $ = "/proc/cpuinfo" fullword
-        $ = "/windows/system32/"
-        $ = "WScript.Shell"
-        $ = "WinExec"
-        $ = "b374k" fullword nocase
-        $ = "backdoor" fullword nocase
-        $ = "c99shell" fullword nocase
-        $ = "cmd.exe" fullword nocase
-        $ = "defaced" fullword nocase
-        $ = "exploit" fullword nocase
-        $ = "find . -type f" fullword
-        $ = /hack(ing|er)/ nocase
-        $ = "hashcrack" nocase
-        $ = "id_rsa" fullword
-        $ = "ipconfig" fullword nocase
-        $ = "kingdefacer" nocase
-        $ = "locus7s" nocase
-        $ = "ls -la" fullword
-        $ = "nc -l" fullword
-        $ = "ps -aux" fullword
-        $ = "rootkit" fullword nocase
-        $ = "slowloris" fullword nocase
-        $ = "uname -a" fullword
-        $ = "warez" fullword nocase
-        $ = /(reverse|web)\s*shell/ nocase
+        $dots = "/../../../"
+        $bin_bash = /\/bin\/(ba)?sh/ fullword
+        $passwd = "/etc/passwd"
+        $proftpd = "/etc/proftpd.conf"
+        $resol = "/etc/resolv.conf"
+        $shadow = "/etc/shadow"
+        $syslog = "/etc/syslog.conf"
+        $cpuinfo = "/proc/cpuinfo" fullword
+        $system32 = "/windows/system32/"
+        $wscript = "WScript.Shell"
+        $winExec = "WinExec"
+        $b374k = "b374k" fullword nocase
+        $backdoor = "backdoor" fullword nocase
+        $c99shell = "c99shell" fullword nocase
+        $cmd = "cmd.exe" fullword nocase
+        $defaced = "defaced" fullword nocase
+        $exploit = "exploit" fullword nocase
+        $find = "find . -type f" fullword
+        $hack = /hack(ing|er)/ nocase
+        $hashcrack = "hashcrack" nocase
+        $rsa = "id_rsa" fullword
+        $ipconfig = "ipconfig" fullword nocase
+        $kingdefacer = "kingdefacer" nocase
+        $locus7s = "locus7s" nocase
+        $ls = "ls -la" fullword
+        $nc = "nc -l" fullword
+        $ps = "ps -aux" fullword
+        $rootkit = "rootkit" fullword nocase
+        $slowloris = "slowloris" fullword nocase
+        $uname = "uname -a" fullword
+        $warez = "warez" fullword nocase
+        $webshell = /(reverse|web)\s*shell/ nocase
 
         $vbs = /language\s*=\s*vbscript/ nocase
         $asp = "scripting.filesystemobject" nocase
@@ -218,23 +218,23 @@ rule DodgyStrings
 rule Websites
 {
     strings:
-        $ = "1337day.com"
-        $ = "antichat.ru"
-        $ = "ccteam.ru"
-        $ = "crackfor" nocase
-        $ = "darkc0de" nocase
-        $ = "egyspider.eu"
-        $ = "exploit-db.com"
-        $ = "fopo.com.ar"  /* Free Online Php Obfuscator */
-        $ = "hashchecker.com"
-        $ = "hashkiller.com" nocase
-        $ = "md5crack.com"
-        $ = "md5decrypter.com"
-        $ = "milw0rm.com"
-        $ = "packetstormsecurity" nocase
-        $ = "rapid7.com"
-        $ = "securityfocus" nocase
-        $ = "shodan.io"
+        $1137day = "1337day.com"
+        $antichat = "antichat.ru"
+        $ccteam = "ccteam.ru"
+        $crackfor = "crackfor" nocase
+        $darkc0de = "darkc0de" nocase
+        $egyspider = "egyspider.eu"
+        $exploit = "exploit-db.com"
+        $fopo = "fopo.com.ar"  /* Free Online Php Obfuscator */
+        $hashchecker = "hashchecker.com"
+        $hashkiller = "hashkiller.com" nocase
+        $md5crack = "md5crack.com"
+        $md5decrypter = "md5decrypter.com"
+        $milw0rm = "milw0rm.com"
+        $packetstormsecurity = "packetstormsecurity" nocase
+        $rapid7 = "rapid7.com"
+        $securityfocus = "securityfocus" nocase
+        $shodan = "shodan.io"
 
     condition:
         any of them and not IsWhitelisted


### PR DESCRIPTION
yara 3.4.0 doesn't complain about duplicate string identifiers. This behavior has been fixed 9 days ago in f867aee70cf52e1ea70ee7b4c2deee09a6cb10b8 

Before the fix : 

```
./phpmalwarefinder -v  /mnt/server/lv_root/var/www/html
./malwares.yara(34): error: duplicated string identifier "$"
./malwares.yara(50): error: duplicated string identifier "$"
./malwares.yara(137): error: duplicated string identifier "$"
./malwares.yara(179): error: duplicated string identifier "$"
./malwares.yara(222): error: duplicated string identifier "$"
```
